### PR TITLE
feat: add Livewire 4 and Laravel 13 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
     "require": {
         "php": "^8.3",
         "spatie/laravel-package-tools": "^1.16",
-        "livewire/livewire": "^3.2.3",
-        "illuminate/contracts": "^10.0||^11.0||^12.0"
+        "livewire/livewire": "^3.2.3|^4.0",
+        "illuminate/contracts": "^10.0||^11.0||^12.0||^13.0"
     },
     "require-dev": {
         "laravel/pint": "^1.14",

--- a/resources/views/modal-content.blade.php
+++ b/resources/views/modal-content.blade.php
@@ -7,7 +7,3 @@
         </div>
     @endif
 @endforeach
-
-@unless (count($components))
-    <p>Something happends... we can't show the modal.</p>
-@endunless

--- a/resources/views/modal.blade.php
+++ b/resources/views/modal.blade.php
@@ -2,7 +2,7 @@
     @include('laravel-livewire-modal::modal-script', ['modalScript' => $modalScript])
 
     <div x-data="LivewireUIModal()" x-on:close.stop="setShowPropertyTo(false)" wire:cloak
-        x-on:keydown.escape.window="show && closeModalOnEscape()" x-show="show" class="fixed inset-0 z-20 overflow-y-auto"
+        x-on:keydown.escape.window="show && closeModalOnEscape()" x-show="show" class="fixed inset-0 z-50 overflow-y-auto"
         style="display: none;">
 
         <div class="flex items-end justify-center min-h-dvh px-4 pt-4 pb-10 text-center sm:block sm:p-0 livewire-modal-wrapper">
@@ -44,7 +44,7 @@
                 x-transition:leave-start="translate-x-0"
                 x-transition:leave-end="translate-x-full"
                 x-bind:class="modalWidth"
-                class="fixed h-full md:w-[25rem] top-0 right-0 border-s overflow-y-auto overflow-x-hidden
+                class="fixed h-full md:w-[32rem] top-0 right-0 border-s overflow-y-auto overflow-x-hidden
                 z-50 shadow-2xl modal-flyout-right bg-white dark:bg-zinc-800 border-zinc-200 dark:border-zinc-700 transform transition-all text-left"
                 id="modal-container-right" x-trap.noscroll="show && showActiveComponent && modalFlyout && modalFlyoutPosition === 'right'" aria-modal="true">
                     @include('laravel-livewire-modal::modal-content', [

--- a/src/Services/ModalManagerService.php
+++ b/src/Services/ModalManagerService.php
@@ -8,7 +8,6 @@ use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Reflector;
 use Livewire\Component;
-use Livewire\Mechanisms\ComponentRegistry;
 use ReflectionClass;
 use ReflectionProperty;
 
@@ -29,7 +28,7 @@ class ModalManagerService
      */
     public function createModalComponent(string $component, array $arguments = [], array $modalAttributes = []): array
     {
-        $componentClass = app(ComponentRegistry::class)->getClass($component);
+        $componentClass = app('livewire.factory')->resolveComponentClass($component);
         $reflect = new ReflectionClass($componentClass);
 
         if ($reflect->isAbstract()) {


### PR DESCRIPTION
- Support livewire/livewire ^4.0 and illuminate/contracts ^13.0
- Replace deprecated ComponentRegistry with livewire.factory resolver
- Fix z-index from z-20 to z-50 so modal overlays properly
- Widen flyout panel from 25rem to 32rem for better content display
- Remove unnecessary fallback error message in modal-content view